### PR TITLE
Feature/#28: 링크디테일 뷰 구현

### DIFF
--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgDetail.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgDetail.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF9",
+          "green" : "0xF4",
+          "red" : "0xEC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF9",
+          "green" : "0xF4",
+          "red" : "0xEC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x22",
+          "green" : "0x1B",
+          "red" : "0x0F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgWhat.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgWhat.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xF2",
+          "red" : "0xFC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xF2",
+          "red" : "0xFC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x20",
+          "green" : "0x12",
+          "red" : "0x21"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgWhy.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgWhy.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE9",
+          "green" : "0xF8",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE9",
+          "green" : "0xF8",
+          "red" : "0xF9"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x1B",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Text/textDetail.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Text/textDetail.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0xAC",
+          "red" : "0x15"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xE5",
+          "green" : "0xAC",
+          "red" : "0x15"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xD8",
+          "green" : "0xA0",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Text/textWhat.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Text/textWhat.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xED",
+          "green" : "0x47",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xED",
+          "green" : "0x47",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xED",
+          "green" : "0x47",
+          "red" : "0xF2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Text/textWhy.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Text/textWhy.colorset/Contents.json
@@ -1,0 +1,56 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x10",
+          "green" : "0x92",
+          "red" : "0xDE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "light"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x10",
+          "green" : "0x92",
+          "red" : "0xDE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0xAE",
+          "red" : "0xC6"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Nbs/Projects/DesignSystem/Sources/Foundation/Color+.swift
+++ b/Nbs/Projects/DesignSystem/Sources/Foundation/Color+.swift
@@ -25,6 +25,10 @@ public extension ShapeStyle where Self == Color {
   /// 기본 배경색
   static var background: Color { DesignSystemAsset.background.swiftUIColor }
   static var alert: Color { DesignSystemAsset.alert.swiftUIColor }
+  static var bgWhat: Color { DesignSystemAsset.bgWhat.swiftUIColor }
+  static var bgWhy: Color { DesignSystemAsset.bgWhy.swiftUIColor }
+  static var bgDetail: Color { DesignSystemAsset.bgDetail.swiftUIColor }
+  
   /// 딤(모달/시트 배경에 사용)
   static var dim: Color { DesignSystemAsset.dim.swiftUIColor }
 
@@ -39,6 +43,10 @@ public extension ShapeStyle where Self == Color {
   static var caption2: Color { DesignSystemAsset.caption2.swiftUIColor }
   /// 캡션/보조 텍스트3
   static var caption3: Color { DesignSystemAsset.caption3.swiftUIColor }
+  
+  static var textWhat: Color { DesignSystemAsset.textWhat.swiftUIColor }
+  static var textWhy: Color { DesignSystemAsset.textWhy.swiftUIColor }
+  static var textDetail: Color { DesignSystemAsset.textDetail.swiftUIColor }
 
   // MARK: Divider
   static var divider1: Color { DesignSystemAsset.divider1.swiftUIColor }

--- a/Nbs/Projects/Feature/Sources/Home/Feature/HomeFeature.swift
+++ b/Nbs/Projects/Feature/Sources/Home/Feature/HomeFeature.swift
@@ -76,12 +76,12 @@ struct HomeFeature {
         
         /// 기사 탭 -> 링크 디테일
       case let .articleList(.delegate(.openLinkDetail(article))):
-        state.path.append(.linkDetail(LinkDetailFeature.State(articleTitle: article.title)))
+        state.path.append(.linkDetail(LinkDetailFeature.State(article: article)))
         return .none
        
         /// 링크 리스트 -> 내부 기사 클릭
       case let .path(.element(_, .linkList(.delegate(.openLinkDetail(article))))):
-        state.path.append(.linkDetail(LinkDetailFeature.State(articleTitle: article.title)))
+        state.path.append(.linkDetail(LinkDetailFeature.State(article: article)))
         return .none
         
       case .dismissAlertBanner:

--- a/Nbs/Projects/Feature/Sources/Home/MockData/MockArticles.swift
+++ b/Nbs/Projects/Feature/Sources/Home/MockData/MockArticles.swift
@@ -8,7 +8,7 @@
 import Foundation
 import DesignSystem
 
-struct MockArticle: ArticleDisplayable, Identifiable {
+struct MockArticle: ArticleDisplayable, Identifiable, Equatable {
   var id: UUID = UUID()
   var url: String? = "https://example.com"
   var imageURL: String? = "https://example.com/image.jpg"

--- a/Nbs/Projects/Feature/Sources/Home/MockData/MockHighlightItem.swift
+++ b/Nbs/Projects/Feature/Sources/Home/MockData/MockHighlightItem.swift
@@ -1,0 +1,58 @@
+//
+//  MockHighlightItem.swift
+//  Feature
+//
+//  Created by 이안 on 10/19/25.
+//
+
+import Foundation
+import Domain
+
+/// SwiftData 없이 View에서 미리보기용으로 사용하는 Mock 데이터 모델
+struct MockHighlightItem: Identifiable {
+  let id: String
+  let sentence: String
+  let type: String
+  let createdAt: Date
+  let comments: [Comment]
+  
+  init(id: String = UUID().uuidString,
+       sentence: String,
+       type: String,
+       createdAt: Date = .now,
+       comments: [Comment] = []) {
+    self.id = id
+    self.sentence = sentence
+    self.type = type
+    self.createdAt = createdAt
+    self.comments = comments
+  }
+}
+
+extension MockHighlightItem {
+  static let mockData: [MockHighlightItem] = [
+    MockHighlightItem(
+      sentence: "국내 산업 현장 곳곳에서 로봇 활용이 빠르게 늘고 있지만, 정작 로봇을 움직이는 핵심 부품 대부분은 여전히 외국산에 의존하는 것으로 나타났는데 미래 산업으로 꼽히는 로봇의 부품들을 일본과 중국에서 조달하면서 우리 산업의 경쟁력이 하락할 것이라는 우려가 나온다.",
+      type: "What",
+      comments: [
+        Comment(id: 1, type: "What", text: "우리나라 로봇 핵심 부품 해외 의존 중 -> 일본과 중국에서 조달 중임"),
+        Comment(id: 2, type: "Detail", text: "AI가 사회 변화에 미치는 영향 강조")
+      ]
+    ),
+    MockHighlightItem(
+      sentence: "로봇의 수요는 급격히 증가하고 있지만, 세부 부품은 대부분 해외에서 조달하는 상황인 셈이다.",
+      type: "Why",
+      comments: [
+        Comment(id: 3, type: "Why", text: "해외에서 조달 중"),
+        Comment(id: 4, type: "Detail", text: "긍정적·부정적 영향 모두 포함")
+      ]
+    ),
+    MockHighlightItem(
+      sentence: "공급망 규모가 작다 보니 대량 조달이 어려워 부품 가격을 줄일 수 없기 때문이다.",
+      type: "Detail",
+      comments: [
+        Comment(id: 5, type: "Detail", text: "대량 생산을 안해서 부품 가격 네고 불가")
+      ]
+    )
+  ]
+}

--- a/Nbs/Projects/Feature/Sources/LinkDetail/Reducer/LinkDetailFeature.swift
+++ b/Nbs/Projects/Feature/Sources/LinkDetail/Reducer/LinkDetailFeature.swift
@@ -10,8 +10,8 @@ import ComposableArchitecture
 @Reducer
 struct LinkDetailFeature {
   @ObservableState
-  struct State {
-    var articleTitle: String = ""
+  struct State: Equatable {
+    var article: MockArticle
   }
   
   enum Action {

--- a/Nbs/Projects/Feature/Sources/LinkDetail/View/AddMemoView.swift
+++ b/Nbs/Projects/Feature/Sources/LinkDetail/View/AddMemoView.swift
@@ -1,0 +1,130 @@
+//
+//  AddMemoView.swift
+//  Feature
+//
+//  Created by 이안 on 10/19/25.
+//
+
+import SwiftUI
+import DesignSystem
+
+/// 추가 메모뷰
+struct AddMemoView: View {
+  // MARK: - State
+  @State private var memoText: String = ""
+  @State private var isEditing: Bool = false
+  @FocusState private var isFocused: Bool
+  
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      if isEditing {
+        editingView
+      } else {
+        displayView
+      }
+    }
+    .padding(.horizontal, 20)
+    .padding(.vertical, 16)
+    .animation(.easeInOut(duration: 0.25), value: isEditing)
+    .background(Color.background)
+    .onTapGesture {
+      if memoText.isEmpty {
+        withAnimation {
+          isEditing = true
+          isFocused = true
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Subviews
+extension AddMemoView {
+  
+  /// ✏️ 작성 중 (TextEditor)
+  private var editingView: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Text("메모 작성 중")
+          .font(.B2_M)
+          .foregroundStyle(.caption2)
+        Spacer()
+        Button("완료") {
+          withAnimation {
+            isEditing = false
+            isFocused = false
+          }
+        }
+        .font(.B2_M)
+        .foregroundStyle(.bl6)
+      }
+      
+      TextEditor(text: $memoText)
+        .focused($isFocused)
+        .font(.B1_M)
+        .foregroundStyle(.text1)
+        .scrollContentBackground(.hidden)
+        .padding(12)
+        .frame(minHeight: 160, alignment: .topLeading)
+        .background(Color.n0)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .shadow(color: .black.opacity(0.05), radius: 3, x: 0, y: 2)
+        .overlay(
+          RoundedRectangle(cornerRadius: 12)
+            .stroke(Color.divider1, lineWidth: 1)
+        )
+    }
+  }
+  
+  /// 📄 읽기 모드
+  private var displayView: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      if memoText.isEmpty {
+        RoundedRectangle(cornerRadius: 12)
+          .fill(Color.n10)
+          .overlay(
+            Text("추가할 메모를 입력해주세요")
+              .font(.B1_M_HL)
+              .foregroundStyle(.caption2)
+          )
+          .frame(height: 160)
+      } else {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Text("추가 메모")
+              .font(.B2_M)
+              .foregroundStyle(.caption2)
+            Spacer()
+            Button {
+              withAnimation {
+                isEditing = true
+                isFocused = true
+              }
+            } label: {
+              Image(systemName: "square.and.pencil")
+                .foregroundColor(.bl6)
+            }
+          }
+          
+          ScrollView {
+            Text(memoText)
+              .font(.B1_M)
+              .foregroundStyle(.text1)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(12)
+              .background(Color.n0)
+              .clipShape(RoundedRectangle(cornerRadius: 12))
+          }
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Preview
+#Preview("LinkMemoView") {
+  VStack(spacing: 24) {
+    AddMemoView()
+  }
+  .padding()
+}

--- a/Nbs/Projects/Feature/Sources/LinkDetail/View/LinkDetailView.swift
+++ b/Nbs/Projects/Feature/Sources/LinkDetail/View/LinkDetailView.swift
@@ -11,28 +11,138 @@ import DesignSystem
 
 struct LinkDetailView {
   @Environment(\.dismiss) private var dismiss
-  let store: StoreOf<LinkDetailFeature>
+  @Bindable var store: StoreOf<LinkDetailFeature>
+  @State private var selectedTab: LinkDetailSegment.Tab = .summary
+
 }
 
 extension LinkDetailView: View {
   var body: some View {
-    VStack(spacing: 16) {
-      TopAppBarDefault(
-        title: "링크 상세",
-        onTapBackButton: { dismiss()}, // 상위 NavigationStack에서 처리됨
-        onTapSearchButton: {},
-        onTapSettingButton: {}
-      )
-      .padding(.bottom, 8)
-      
-      Spacer()
-      
-      Text("📰 \(store.articleTitle.isEmpty ? "헬로우" : store.articleTitle)")
-        .font(.title2)
-        .foregroundColor(.primary)
-      
-      Spacer()
+    ZStack {
+      Color.background
+        .ignoresSafeArea()
+      VStack {
+        navigationBar
+        ScrollView {
+          LazyVStack(spacing: 24) {
+            articleContensts
+            bottomContents
+          }
+        }
+      }
+      .navigationBarHidden(true)
+      .onAppear { store.send(.onAppear) }
     }
-    .navigationBarHidden(true)
   }
+  
+  /// 네비게이션바
+  private var navigationBar: some View {
+    TopAppBarDefault(
+      title: "",
+      onTapBackButton: { dismiss() },
+      onTapSearchButton: {},
+      onTapSettingButton: {}
+    )
+  }
+  
+  /// 상단 컨텐츠
+  private var articleContensts: some View {
+    VStack(alignment: .leading, spacing: 24) {
+      articleInfo
+      articleLink
+    }
+    .padding(.horizontal, 20)
+  }
+  
+  /// 기사 타이틀 + 정보 섹션
+  private var articleInfo: some View {
+    VStack(alignment: .leading, spacing: 24) {
+      // 기사 타이틀
+      Text(store.article.title)
+        .font(.H1)
+        .foregroundStyle(.text1)
+        .multilineTextAlignment(.leading)
+        .lineLimit(nil)
+      
+      // 정보 섹션
+      VStack(alignment: .leading, spacing: 12) {
+        ArticleInfoItem(icon: Icon.calendar, text: store.article.dateToString)
+        ArticleInfoItem(icon: Icon.book, text: store.article.newsCompany)
+        ArticleInfoItem(icon: Icon.tag, text: "뉴스 카테고리")
+      }
+    }
+  }
+  
+  /// 링크 원문 보기
+  private var articleLink: some View {
+    Button {
+      if let url = store.article.url,
+         let link = URL(string: url) {
+        UIApplication.shared.open(link)
+      }
+    } label: {
+      HStack(spacing: 12) {
+        Image(systemName: "photo")
+          .resizable()
+          .scaledToFit()
+          .frame(width: 48, height: 48)
+          .cornerRadius(8)
+        
+        VStack(alignment: .leading, spacing: 4) {
+          Text("링크 원문 보기")
+            .font(.B1_M)
+            .foregroundStyle(.text1)
+            .lineLimit(1)
+          
+          if let url = store.article.url {
+            Text(url)
+              .lineLimit(1)
+              .font(.C2)
+              .foregroundStyle(.caption2)
+          }
+        }
+        
+        Spacer()
+        
+        Image(icon: Icon.chevronRight)
+          .renderingMode(.template)
+          .resizable()
+          .scaledToFit()
+          .foregroundStyle(.icon)
+          .frame(width: 24, height: 24)
+      }
+      .padding(12)
+      .background {
+        RoundedRectangle(cornerRadius: 12)
+          .fill(.n0)
+      }
+    }
+    .buttonStyle(.plain)
+  }
+  
+  private var bottomContents: some View {
+    VStack {
+      LinkDetailSegment(selectedTab: $selectedTab)
+        .frame(height: 37)
+
+      switch selectedTab {
+      case .summary:
+        SummaryView(highlights: MockHighlightItem.mockData)
+      case .memo:
+        AddMemoView()
+      }
+    }
+  }
+}
+
+#Preview {
+  LinkDetailView(
+    store: Store(
+      initialState: LinkDetailFeature.State(
+        article: MockArticle.mockArticles.first!
+      )
+    ) {
+      LinkDetailFeature()
+    }
+  )
 }

--- a/Nbs/Projects/Feature/Sources/LinkDetail/View/SummaryView.swift
+++ b/Nbs/Projects/Feature/Sources/LinkDetail/View/SummaryView.swift
@@ -1,0 +1,75 @@
+//
+//  SummaryView.swift
+//  Feature
+//
+//  Created by 이안 on 10/19/25.
+//
+
+//
+//  SummaryView.swift
+//  Feature
+//
+
+import SwiftUI
+import Domain
+
+struct SummaryView: View {
+  let highlights: [MockHighlightItem]
+}
+
+extension SummaryView {
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 32) {
+        ForEach(highlights) { item in
+          let type = SummaryTypeItem.SummaryType(rawValue: item.type) ?? .what
+          
+          VStack(alignment: .leading, spacing: 24) {
+            // 타입 라벨 (What / Why / Detail)
+            SummaryTypeItem(type: type)
+            
+            // 실제 하이라이트 문장 및 코멘트
+            highlightContents(for: item, type: type)
+          }
+        }
+      }
+      .padding(.horizontal, 20)
+      .padding(.vertical, 24)
+    }
+    .background(Color.background)
+  }
+  
+  /// 하이라이트 섹션
+  private func highlightContents(for item: MockHighlightItem, type: SummaryTypeItem.SummaryType) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+      // 문장 (하이라이팅)
+      Text(item.sentence)
+        .font(.B1_M_HL)
+        .foregroundStyle(.text1)
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(type.backgroundColor)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+      
+      // 코멘트 리스트
+      if !item.comments.isEmpty {
+        VStack(alignment: .leading, spacing: 8) {
+          ForEach(item.comments, id: \.id) { comment in
+            Text("\(comment.text)")
+              .font(.B3_R_HLM)
+              .foregroundStyle(.caption1)
+          }
+        }
+        .padding(.horizontal, 16)
+      }
+      
+      Rectangle()
+        .fill(.divider1)
+        .frame(height: 1)
+    }
+  }
+}
+
+#Preview {
+  SummaryView(highlights: MockHighlightItem.mockData)
+}

--- a/Nbs/Projects/Feature/Sources/LinkList/View/CategoryChipList.swift
+++ b/Nbs/Projects/Feature/Sources/LinkList/View/CategoryChipList.swift
@@ -29,7 +29,7 @@ extension CategoryChipList: View {
   private var categoryChipList: some View {
     ScrollViewReader { proxy in
       ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: 6) {
+        LazyHStack(spacing: 6) {
           ForEach(store.categories, id: \.self) { category in
             ChipButton(
               title: category,

--- a/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/ArticleInfoItem.swift
+++ b/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/ArticleInfoItem.swift
@@ -1,0 +1,29 @@
+//
+//  ArticleInfoItem.swift
+//  Feature
+//
+//  Created by 이안 on 10/19/25.
+//
+
+import SwiftUI
+
+/// 기사 정보 아이템 (날짜, 언론사명, 카테고리)
+struct ArticleInfoItem: View {
+  let icon: String
+  let text: String
+  
+  var body: some View {
+    HStack(spacing: 8) {
+      Image(icon: icon)
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(width: 24, height: 24)
+        .foregroundStyle(.bl4)
+      
+      Text(text)
+        .font(.B1_M)
+        .foregroundStyle(.caption1)
+    }
+  }
+}

--- a/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/LinkDetailSegment.swift
+++ b/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/LinkDetailSegment.swift
@@ -1,0 +1,57 @@
+//
+//  LinkDetailSegment.swift
+//  Feature
+//
+//  Created by 이안 on 10/19/25.
+//
+
+import SwiftUI
+import DesignSystem
+
+/// 링크 상세 하단 세그먼트 (예: 요약 / 추가 메모)
+struct LinkDetailSegment: View {
+  @Binding var selectedTab: Tab
+  
+  enum Tab: String, CaseIterable {
+    case summary = "요약"
+    case memo = "추가 메모"
+  }
+}
+
+// MARK: - Body
+extension LinkDetailSegment {
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 10) {
+        ForEach(Tab.allCases, id: \.self) { tab in
+          Button {
+            withAnimation(.easeInOut(duration: 0.25)) {
+              selectedTab = tab
+            }
+          } label: {
+            VStack(alignment: .center, spacing: 4) {
+              Text(tab.rawValue)
+                .font(.B1_M)
+                .foregroundStyle(selectedTab == tab ? .bl6 : .caption3)
+                .frame(maxWidth: .infinity)
+              
+              Rectangle()
+                .fill(selectedTab == tab ? Color.bl6 : .clear)
+                .frame(height: 4)
+                .cornerRadius(16)
+                .animation(.easeInOut, value: selectedTab)
+            }
+            .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .padding(.horizontal, 22.5)
+      .background(Color.background)
+      
+      Divider()
+        .frame(height: 1)
+        .foregroundStyle(.divider1)
+    }
+  }
+}

--- a/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/SummaryTypeItem.swift
+++ b/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/SummaryTypeItem.swift
@@ -1,0 +1,69 @@
+//
+//  SummaryTypeItem.swift
+//  Feature
+//
+//  Created by 이안 on 10/19/25.
+//
+
+import SwiftUI
+import DesignSystem
+
+/// 요약 아이템 (What / Why / Detail)
+struct SummaryTypeItem: View {
+  enum SummaryType: String {
+    case what = "What"
+    case why = "Why"
+    case detail = "Detail"
+    
+    var textColor: Color {
+      switch self {
+      case .what: return .textWhat
+      case .why: return .textWhy
+      case .detail: return .textDetail
+      }
+    }
+    
+    var backgroundColor: Color {
+      switch self {
+      case .what: return .bgWhat
+      case .why: return .bgWhy
+      case .detail: return .bgDetail
+      }
+    }
+    
+    var shortLabel: String {
+      switch self {
+      case .what: return "W"
+      case .why: return "W"
+      case .detail: return "D"
+      }
+    }
+  }
+  
+  let type: SummaryType
+}
+
+extension SummaryTypeItem {
+  var body: some View {
+    HStack(spacing: 8) {
+      Text(type.shortLabel)
+        .font(.B2_M)
+        .foregroundStyle(type.textColor)
+        .frame(width: 24, height: 24)
+        .background(type.backgroundColor)
+        .cornerRadius(4)
+      
+      Text(type.rawValue)
+        .font(.B1_M)
+        .foregroundStyle(type.textColor)
+    }
+  }
+}
+
+#Preview {
+  VStack(spacing: 16) {
+    SummaryTypeItem(type: .what)
+    SummaryTypeItem(type: .why)
+    SummaryTypeItem(type: .detail)
+  }
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #28 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 새로운 컴포넌트 `ArticleItem`, `LinkDetailSegment`, `SummaryTypeItem` 추가
- Color 값 추가
- LinkDetailView 구현

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/6c98700a-62d8-44c5-929b-730ba7084c54

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 현재 컴포넌트와 조금 다를 수 있습니다.
- Navigation과 SwiftData 불러오기 완료 후에 디테일 잡을 예정입니다.