### PR TITLE
Feat: #51 검색 필터기능 구현

### DIFF
--- a/Nbs/Projects/DesignSystem/Sources/Components/Sheet/Select/SelectBottomSheet.swift
+++ b/Nbs/Projects/DesignSystem/Sources/Components/Sheet/Select/SelectBottomSheet.swift
@@ -9,10 +9,10 @@ import SwiftUI
 
 // MARK: - Model
 public struct CategoryProps: Identifiable, Equatable {
-  public let id: String
+  public let id: UUID
   public let title: String
   
-  public init(id: String, title: String) {
+  public init(id: UUID, title: String) {
     self.id = id
     self.title = title
   }
@@ -22,24 +22,25 @@ public struct CategoryProps: Identifiable, Equatable {
 public struct SelectBottomSheet: View {
   let sheetTitle: String
   let items: [CategoryProps]
-  let categoryButtonTapped: (String) -> Void 
+  let categoryButtonTapped: (String) -> Void
   let selectButtonTapped: () -> Void
   let dismissButtonTapped: () -> Void
+  let selectedCategory: String?
   
-  @State private var selectedItemID: String?
-
   public init(
     sheetTitle: String,
     items: [CategoryProps],
     categoryButtonTapped: @escaping (String) -> Void,
     selectButtonTapped: @escaping () -> Void,
-    dismissButtonTapped: @escaping () -> Void
+    dismissButtonTapped: @escaping () -> Void,
+    selectedCategory: String?
   ) {
     self.sheetTitle = sheetTitle
     self.items = items
     self.categoryButtonTapped = categoryButtonTapped
     self.selectButtonTapped = selectButtonTapped
     self.dismissButtonTapped = dismissButtonTapped
+    self.selectedCategory = selectedCategory
   }
 }
 
@@ -67,10 +68,11 @@ extension SelectBottomSheet {
       ScrollView(.vertical, showsIndicators: false) {
         LazyVStack {
           ForEach(items) { item in
-            SelectBottomSheetItem(title: item.title, isSelected: selectedItemID == item.id, action: {
-              self.selectedItemID = item.id
-              categoryButtonTapped(item.id)
-            })
+            SelectBottomSheetItem(
+              title: item.title,
+              isSelected: item.title == selectedCategory,
+              action: { categoryButtonTapped(item.title) }
+            )
           }
         }
       }
@@ -87,12 +89,13 @@ extension SelectBottomSheet {
   SelectBottomSheet(
     sheetTitle: "카테고리 필터",
     items: [
-      .init(id: "1", title: "전체"),
-      .init(id: "2", title: "정치"),
-      .init(id: "3", title: "경제")
+      .init(id: UUID(), title: "1"),
+      .init(id: UUID(), title: "2"),
+      .init(id: UUID(), title: "3"),
     ],
     categoryButtonTapped: { _ in },
     selectButtonTapped: {},
-    dismissButtonTapped: {} 
+    dismissButtonTapped: {},
+    selectedCategory: "2"
   )
 }

--- a/Nbs/Projects/DesignSystem/Sources/Components/Sheet/Select/SelectBottomSheetItem.swift
+++ b/Nbs/Projects/DesignSystem/Sources/Components/Sheet/Select/SelectBottomSheetItem.swift
@@ -10,7 +10,7 @@ import SwiftUI
 // MARK: - Properties
 struct SelectBottomSheetItem: View {
   let title: String
-  @State var isSelected: Bool = false
+  let isSelected: Bool 
   
   let action: () -> Void
   
@@ -33,7 +33,7 @@ struct SelectBottomSheetItem: View {
 extension SelectBottomSheetItem {
   var body: some View {
     Button {
-      print("tap")
+      action()
     } label: {
       HStack {
         Text(title)

--- a/Nbs/Projects/DesignSystem/Sources/Components/Sheet/Select/SelectBottomSheetItem.swift
+++ b/Nbs/Projects/DesignSystem/Sources/Components/Sheet/Select/SelectBottomSheetItem.swift
@@ -24,10 +24,6 @@ struct SelectBottomSheetItem: View {
     self.action = action
   }
   
-//  private var font: Font {
-//    isSelected ? .B1_SB : .B1_M
-//  }
-  
   private var foregroundColor: Color {
     isSelected ? .bl6 : .text1
   }

--- a/Nbs/Projects/Domain/Sources/SwiftDataModel/CategoryItem.swift
+++ b/Nbs/Projects/Domain/Sources/SwiftDataModel/CategoryItem.swift
@@ -21,7 +21,8 @@ public struct CategoryIcon: Codable, Hashable {
 }
 
 @Model
-public final class CategoryItem {
+public final class CategoryItem: Identifiable {
+  @Attribute(.unique) public var id: UUID
   @Attribute(.unique) public var categoryName: String // 카테고리 이름
   public var createdAt: Date
   public var icon: CategoryIcon
@@ -32,6 +33,7 @@ public final class CategoryItem {
     categoryName: String,
     icon: CategoryIcon
   ) {
+    self.id = UUID()
     self.categoryName = categoryName
     self.createdAt = Date()
     self.icon = icon

--- a/Nbs/Projects/Feature/Sources/Search/Feature/SearchResultFeature.swift
+++ b/Nbs/Projects/Feature/Sources/Search/Feature/SearchResultFeature.swift
@@ -9,6 +9,7 @@ import ComposableArchitecture
 
 import Foundation
 
+import DesignSystem
 import Domain
 
 @Reducer
@@ -16,7 +17,11 @@ struct SearchResultFeature {
   @ObservableState
   struct State: Equatable {
     var searchResult: [LinkItem] = []
+    var filteredSearchResult: [LinkItem] = []
     var query: String = ""
+    var selectedCategoryTitle: String = "카테고리"
+    
+    @Presents var selectBottomSheet: SelectBottomSheetFeature.State?
   }
   
   enum Action: Equatable {
@@ -24,6 +29,10 @@ struct SearchResultFeature {
     case searchResponse([LinkItem])
     case linkCardTapped(LinkItem)
     case categoryButtonTapped
+    
+    case selectBottomSheet(PresentationAction<SelectBottomSheetFeature.Action>)
+    case fetchAllCategories
+    case responseCategoryItems([CategoryItem])
     
     case delegate(DelegateAction)
   }
@@ -33,6 +42,7 @@ struct SearchResultFeature {
   }
   
   @Dependency(\.swiftDataClient) var swiftDataClient
+  @Dependency(\.uuid) var uuid
   
   var body: some ReducerOf<Self> {
     Reduce { state, action in
@@ -43,20 +53,62 @@ struct SearchResultFeature {
           let response = try swiftDataClient.searchLinks(query)
           await send(.searchResponse(response))
         }
-      
+        
       case .searchResponse(let item):
         state.searchResult = item
+        state.filteredSearchResult = item
         return .none
-      
+        
       case .linkCardTapped(let item):
         return .send(.delegate(.openLinkDetail(item)))
         
       case .categoryButtonTapped:
+        return .send(.fetchAllCategories)
+        
+      case .fetchAllCategories:
+        return .run { send in
+          let categoryItems = try swiftDataClient.fetchCategories()
+          await send(.responseCategoryItems(categoryItems))
+        }
+        
+      case .responseCategoryItems(let items):
+        let allCategory = CategoryProps(id: uuid(), title: "전체")
+        var categoryProps: [CategoryProps] = items.map { item in
+          CategoryProps(id: uuid(), title: item.categoryName)
+        }
+        categoryProps.insert(allCategory, at: 0)
+        let allCategories = IdentifiedArray(uniqueElements: categoryProps)
+        
+        state.selectBottomSheet = SelectBottomSheetFeature.State(
+          categories: allCategories,
+          selectedCategory: state.selectedCategoryTitle == "카테고리" ? "전체" : state.selectedCategoryTitle
+        )
         return .none
         
-      case .delegate:
+      case .selectBottomSheet(.presented(.delegate(.categorySelected(let category)))):
+        if let category = category {
+          var selectedCategoryTitle: String {
+            category == "전체" ? "카테고리" : category
+          }
+          state.selectedCategoryTitle = selectedCategoryTitle
+          
+          if category == "전체" {
+            state.filteredSearchResult = state.searchResult
+          } else {
+            state.filteredSearchResult = state.searchResult.filter { link in
+              link.category?.categoryName == category
+            }
+          }
+        }
+        return .none
+        
+      case .delegate, .selectBottomSheet:
         return .none
       }
     }
+    .ifLet(\.$selectBottomSheet, action: \.selectBottomSheet) {
+      SelectBottomSheetFeature()
+    }
   }
 }
+

--- a/Nbs/Projects/Feature/Sources/Search/View/SearchResultView.swift
+++ b/Nbs/Projects/Feature/Sources/Search/View/SearchResultView.swift
@@ -35,7 +35,7 @@ extension SearchResultView {
           .foregroundStyle(.caption2)
           .lineLimit(1)
           .padding(.vertical, 6)
-
+        
         Spacer()
         
         if !store.searchResult.isEmpty {
@@ -43,7 +43,7 @@ extension SearchResultView {
             store.send(.categoryButtonTapped)
           } label: {
             HStack(spacing: 6) {
-              Text("카테고리")
+              Text(store.selectedCategoryTitle)
                 .padding(.leading, 18)
                 .foregroundStyle(.caption1)
                 .font(.B2_M)
@@ -65,7 +65,7 @@ extension SearchResultView {
       if !store.searchResult.isEmpty {
         ScrollView(.vertical, showsIndicators: false) {
           LazyVStack {
-            ForEach(store.searchResult) { result in
+            ForEach(store.filteredSearchResult) { result in
               Button {
                 store.send(.linkCardTapped(result))
               } label: {
@@ -86,6 +86,11 @@ extension SearchResultView {
     }
     .padding(.horizontal, 20)
     .background(Color.clear)
+    .sheet(item: $store.scope(state: \.selectBottomSheet, action: \.selectBottomSheet)) { store in
+      TCASelectBottomSheet(title: "카테고리 선택", store: store)
+        .presentationDetents([.medium])
+        .presentationCornerRadius(16)
+    }
   }
 }
 

--- a/Nbs/Projects/Feature/Sources/Search/View/SearchResultView.swift
+++ b/Nbs/Projects/Feature/Sources/Search/View/SearchResultView.swift
@@ -58,6 +58,7 @@ extension SearchResultView {
                 .stroke(.divider1, lineWidth: 1)
             }
           }
+          .buttonStyle(.plain)
         }
       }
       

--- a/Nbs/Projects/Feature/Sources/Search/View/SearchView.swift
+++ b/Nbs/Projects/Feature/Sources/Search/View/SearchView.swift
@@ -15,7 +15,7 @@ import SwiftData
 
 // MARK: - Properties
 struct SearchView: View {
-  @Bindable var store: StoreOf<SearchFeature>
+  let store: StoreOf<SearchFeature>
 }
 
 // MARK: - View

--- a/Nbs/Projects/Feature/Sources/UIComponent/Sheet/Feature/SelectBottomSheetFeature.swift
+++ b/Nbs/Projects/Feature/Sources/UIComponent/Sheet/Feature/SelectBottomSheetFeature.swift
@@ -1,0 +1,63 @@
+//
+//  SelectBottomSheetFeature.swift
+//  Feature
+//
+//  Created by 여성일 on 10/22/25.
+//
+
+import ComposableArchitecture
+import DesignSystem
+import Domain
+import Foundation
+
+@Reducer
+struct SelectBottomSheetFeature {
+  @ObservableState
+  struct State: Equatable {
+    var categories: IdentifiedArrayOf<CategoryProps> = []
+    var selectedCategory: String?
+    
+    init(categories: IdentifiedArrayOf<CategoryProps> = [], selectedCategory: String? = nil) {
+      self.categories = categories
+      self.selectedCategory = selectedCategory
+    }
+  }
+  
+  enum Action: Equatable {
+    case categoryTapped(String)
+    case selectButtonTapped
+    case closeTapped
+    
+    case delegate(DelegateAction)
+  }
+  
+  enum DelegateAction: Equatable {
+    case categorySelected(String?)
+  }
+  
+  @Dependency(\.dismiss) var dismiss
+  @Dependency(\.swiftDataClient) var swiftDataClient
+
+  var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {        
+      case .categoryTapped(let category):
+        print(category)
+        state.selectedCategory = category
+        return .none
+        
+      case .closeTapped:
+        return .run { _ in await self.dismiss() }
+        
+      case .selectButtonTapped:
+        return .run { [selectedCategory = state.selectedCategory] send in
+          await send(.delegate(.categorySelected(selectedCategory)))
+          await self.dismiss()
+        }
+        
+      case .delegate:
+        return .none
+      }
+    }
+  }
+}

--- a/Nbs/Projects/Feature/Sources/UIComponent/Sheet/View/TCASelectBottomSheet.swift
+++ b/Nbs/Projects/Feature/Sources/UIComponent/Sheet/View/TCASelectBottomSheet.swift
@@ -1,0 +1,43 @@
+//
+//  TCASelectBottomSheet.swift
+//  Feature
+//
+//  Created by 여성일 on 10/22/25.
+//
+
+import SwiftUI
+
+import DesignSystem
+import ComposableArchitecture
+
+// MARK: - Properties
+struct TCASelectBottomSheet: View {
+  let title: String
+  let store: StoreOf<SelectBottomSheetFeature>
+}
+
+// MARK: - View
+extension TCASelectBottomSheet {
+  var body: some View {
+    SelectBottomSheet(
+      sheetTitle: title,
+      items: store.categories.elements,
+      categoryButtonTapped: { category in store.send(.categoryTapped(category)) },
+      selectButtonTapped: { store.send(.selectButtonTapped) },
+      dismissButtonTapped: { store.send(.closeTapped) }, selectedCategory: store.selectedCategory
+    )
+    .onAppear {
+      
+    }
+  }
+}
+
+#Preview {
+  TCASelectBottomSheet(
+    title: "카테고리 선택",
+    store: Store(
+      initialState: SelectBottomSheetFeature.State(),
+      reducer: { SelectBottomSheetFeature() }
+    )
+  )
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #51 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 카테고리아이템 모델 수정 : id String타입에서 UUID로 수정했수매~
- 카테고리 시트 컴포넌트 구현 : ❗️이거 할 얘기 많음 밑에 꼭 봐주세여 
- 필터링 기능 구현 

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/0d29cefb-47ec-4b09-8ecc-df8529ff37ec

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 실기기 동작 확인
- [x] 다크모드 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->
<img width="789" height="138" alt="스크린샷 2025-10-22 오전 12 38 27" src="https://github.com/user-attachments/assets/24da9e58-f882-4c6d-9c83-c2f4211ab096" />
자.. 바텀 시트 할 얘기가 참 많습니다요 ..
일단 문제가 뭐냐면, UI에 카테고리 목록을 바인딩 하려면 CategoryItem 모델에 접근 해야하는데, 우리 모델들은 도메인 모듈로 분리 되어 있어서 도메인 모듈에 접근이 필요함 ->  디자인 시스템 모듈에서 도메인 모듈에 접근하려고 하니까 순환참조 발생

해결 방법은 두 가지가 생각 났는데, 첫 번째는 그냥 바텀 시트 컴포넌트 Feature 모듈로 분리하자, 두 번째는 Props 사용해서 데이터 넘길 때 매핑해주자였어요. 둘 다 장단점이 있는데, 모듈화 규칙 깨지는게 싫어서 복잡하지만 두 번째로 했습니다.. 

간단함.. 그냥 BottomSheet 인스턴스 생성할 때 파라미터로 Props 넘겨받게 하고, 카테고리아이템 받아온거 Props로 매핑해서 파라미터로 넘겨주면 끝~ 

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->
