### PR TITLE
Refactor: #94 링크디테일뷰 UI 개선 및 디테일 잡기 

### DIFF
--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgButtonGra1.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgButtonGra1.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.984",
-          "green" : "0.980",
-          "red" : "0.980"
+          "blue" : "0xFA",
+          "green" : "0xF9",
+          "red" : "0xF9"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.078",
-          "green" : "0.063",
-          "red" : "0.063"
+          "blue" : "0x14",
+          "green" : "0x10",
+          "red" : "0x10"
         }
       },
       "idiom" : "universal"

--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgButtonGra2.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgButtonGra2.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.900",
-          "blue" : "0.984",
-          "green" : "0.980",
-          "red" : "0.980"
+          "blue" : "0xFB",
+          "green" : "0xFA",
+          "red" : "0xFA"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.900",
-          "blue" : "0.078",
-          "green" : "0.063",
-          "red" : "0.063"
+          "blue" : "0x14",
+          "green" : "0x10",
+          "red" : "0x10"
         }
       },
       "idiom" : "universal"

--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgButtonGra3.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgButtonGra3.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.200",
-          "blue" : "0.984",
-          "green" : "0.980",
-          "red" : "0.980"
+          "blue" : "0xFB",
+          "green" : "0xFA",
+          "red" : "0xFA"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.200",
-          "blue" : "0.078",
-          "green" : "0.063",
-          "red" : "0.063"
+          "blue" : "0x14",
+          "green" : "0x10",
+          "red" : "0x10"
         }
       },
       "idiom" : "universal"

--- a/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgButtonGra4.colorset/Contents.json
+++ b/Nbs/Projects/DesignSystem/Resources/Assets.xcassets/Background/bgButtonGra4.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.000",
-          "blue" : "0.984",
-          "green" : "0.980",
-          "red" : "0.980"
+          "blue" : "0xFB",
+          "green" : "0xFA",
+          "red" : "0xFA"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "0.000",
-          "blue" : "0.078",
-          "green" : "0.063",
-          "red" : "0.063"
+          "blue" : "0x14",
+          "green" : "0x10",
+          "red" : "0x10"
         }
       },
       "idiom" : "universal"

--- a/Nbs/Projects/DesignSystem/Sources/Components/Button/MainButton.swift
+++ b/Nbs/Projects/DesignSystem/Sources/Components/Button/MainButton.swift
@@ -29,6 +29,7 @@ public struct MainButton: View {
   let title: String
   let style: Style
   let isDisabled: Bool
+  let hasGradient: Bool
   let action: () -> Void
   
   // MARK: - Init
@@ -36,11 +37,13 @@ public struct MainButton: View {
     _ title: String,
     style: Style = .deep,
     isDisabled: Bool = false,
+    hasGradient: Bool = false,
     action: @escaping () -> Void
   ) {
     self.title = title
     self.style = style
     self.isDisabled = isDisabled
+    self.hasGradient = hasGradient
     self.action = action
   }
   
@@ -85,7 +88,34 @@ extension MainButton {
         .background(backgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
+    .padding(.horizontal, 20)
+    .overlay(alignment: .top) {
+      if hasGradient { gradientPart }
+    }
     .disabled(isDisabled)
+  }
+  
+  /// 그라데이션 파트
+  private var gradientPart: some View {
+    Rectangle()
+      .foregroundColor(.clear)
+      .frame(height: 32)
+      .overlay(
+        LinearGradient(
+          stops: [
+            Gradient.Stop(color: .bgButtonGrad1, location: 0.00),
+            Gradient.Stop(color: .bgButtonGrad2, location: 0.16),
+            Gradient.Stop(color: .bgButtonGrad3, location: 0.73),
+            Gradient.Stop(color: .bgButtonGrad4, location: 1.00),
+          ],
+          startPoint: UnitPoint(x: 0.47, y: 1),
+          endPoint: UnitPoint(x: 0.47, y: 0.15)
+        )
+      )
+      .blur(radius: 0)
+      .frame(height: 32)
+      .offset(y: -40)
+      .allowsHitTesting(false)
   }
 }
 
@@ -94,6 +124,7 @@ extension MainButton {
   MainButton(
     "BUTTON",
     style: .deep,
-    isDisabled: false
+    isDisabled: false,
+    hasGradient: true
   ) { print("버튼입니다") }
 }

--- a/Nbs/Projects/DesignSystem/Sources/Components/Sheet/Select/SelectBottomSheet.swift
+++ b/Nbs/Projects/DesignSystem/Sources/Components/Sheet/Select/SelectBottomSheet.swift
@@ -50,44 +50,47 @@ public struct SelectBottomSheet: View {
 // MARK: - View
 extension SelectBottomSheet {
   public var body: some View {
-    VStack {
-      HStack(alignment: .center, spacing: 8) {
-        Text(sheetTitle)
-          .font(.B1_SB)
-          .lineLimit(1)
-          .foregroundStyle(.text1)
-          .frame(maxWidth: .infinity, alignment: .center)
-          .padding(.leading, 48)
-        Button {
-          dismissButtonTapped() // 닫기 버튼 액션 연결
-        } label: {
-          Image(icon: Icon.x)
-            .frame(width: 24, height: 24)
-            .padding(.trailing, 20)
-        }
-      }
-      .padding(.vertical, 20)
-      
-      ScrollView(.vertical, showsIndicators: false) {
-        LazyVStack {
-          ForEach(items) { item in
-            SelectBottomSheetItem(
-              title: item.title,
-              isSelected: item.title == selectedCategory,
-              action: { categoryButtonTapped(item.title) }
-            )
+    ZStack {
+      Color.background.ignoresSafeArea()
+      VStack {
+        HStack(alignment: .center, spacing: 8) {
+          Text(sheetTitle)
+            .font(.B1_SB)
+            .lineLimit(1)
+            .foregroundStyle(.text1)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.leading, 48)
+          Button {
+            dismissButtonTapped() // 닫기 버튼 액션 연결
+          } label: {
+            Image(icon: Icon.x)
+              .frame(width: 24, height: 24)
+              .padding(.trailing, 20)
           }
         }
-      }
-      .padding(.horizontal, 20)
-      
-      MainButton(
-        buttonTitle,
-        action: { selectButtonTapped() }
-      )
+        .padding(.vertical, 20)
+        
+        ScrollView(.vertical, showsIndicators: false) {
+          LazyVStack {
+            ForEach(items) { item in
+              SelectBottomSheetItem(
+                title: item.title,
+                isSelected: item.title == selectedCategory,
+                action: { categoryButtonTapped(item.title) }
+              )
+            }
+          }
+        }
         .padding(.horizontal, 20)
+        
+        MainButton(
+          buttonTitle,
+          hasGradient: true,
+          action: { selectButtonTapped() }
+        )
+      }
+      .padding(.top, 8)
     }
-    .padding(.top, 8)
   }
 }
 

--- a/Nbs/Projects/DesignSystem/Sources/Components/TopAppBar/DefaultDetail.swift
+++ b/Nbs/Projects/DesignSystem/Sources/Components/TopAppBar/DefaultDetail.swift
@@ -74,7 +74,7 @@ extension TopAppBarDefaultDetail: View {
               .contentShape(Rectangle())
           }
         }
-        .padding(.trailing, 24)
+        .padding(.trailing, 10)
       }
       Text(title)
         .font(.H4_SB)

--- a/Nbs/Projects/Feature/Sources/AddLink/View/AddLinkView.swift
+++ b/Nbs/Projects/Feature/Sources/AddLink/View/AddLinkView.swift
@@ -67,11 +67,11 @@ struct AddLinkView: View {
       Spacer()
       MainButton(
         AddLinkNamespace.ctaButtonTitle,
-        isDisabled: store.linkURL.isEmpty
+        isDisabled: store.linkURL.isEmpty,
+        hasGradient: true
       ) {
         store.send(.saveButtonTapped)
       }
-      .padding(.horizontal, 20)
     }
     .ignoresSafeArea(.keyboard)
     .navigationBarHidden(true)

--- a/Nbs/Projects/Feature/Sources/LinkDetail/View/LinkDetailView.swift
+++ b/Nbs/Projects/Feature/Sources/LinkDetail/View/LinkDetailView.swift
@@ -168,6 +168,7 @@ extension LinkDetailView: View {
       .background {
         RoundedRectangle(cornerRadius: 12)
           .fill(.n0)
+          .allowsHitTesting(false)
       }
     }
     .buttonStyle(.plain)

--- a/Nbs/Projects/Feature/Sources/LinkDetail/View/SummaryView.swift
+++ b/Nbs/Projects/Feature/Sources/LinkDetail/View/SummaryView.swift
@@ -17,13 +17,13 @@ extension SummaryView {
       VStack(spacing: 32) {
         ForEach(groupedHighlights.keys.sorted(by: sortOrder), id: \.self) { key in
           if let items = groupedHighlights[key],
-             let type = SummaryTypeItem.SummaryType(rawValue: key) {
+             let displayType = displayType(forModelKey: key) {
             VStack(alignment: .leading, spacing: 24) {
-              SummaryTypeItem(type: type)
+              SummaryTypeItem(type: displayType)
               
-              // 같은 type의 highlight를 모아서 출력
+              // 같은 모델 타입에 묶인 하이라이트들
               ForEach(items) { item in
-                highlightContents(for: item, type: type)
+                highlightContents(for: item, type: displayType)
               }
             }
           }
@@ -63,6 +63,16 @@ extension SummaryView {
       }
     }
   }
+  
+  /// 보여줄 타입
+  private func displayType(forModelKey key: String) -> SummaryTypeItem.SummaryType? {
+     switch key.lowercased() {
+     case "what":   return .pink
+     case "why":    return .yellow
+     case "detail": return .blue
+     default:       return nil
+     }
+   }
   
   ///  type별 그룹핑된 highlights
   private var groupedHighlights: [String: [HighlightItem]] {

--- a/Nbs/Projects/Feature/Sources/MyCategory/View/AddCategoryView.swift
+++ b/Nbs/Projects/Feature/Sources/MyCategory/View/AddCategoryView.swift
@@ -103,11 +103,11 @@ struct AddCategoryView: View {
         .padding(.top, 4)
         MainButton(
           CategoryNamespace.addCategory,
-          isDisabled: store.categoryName.isEmpty
+          isDisabled: store.categoryName.isEmpty,
+          hasGradient: true
         ) {
           store.send(.saveButtonTapped)
         }
-        .padding(.horizontal, 20)
       }
     }
     .background(Color.background)

--- a/Nbs/Projects/Feature/Sources/MyCategory/View/EditCategoryIconNameView.swift
+++ b/Nbs/Projects/Feature/Sources/MyCategory/View/EditCategoryIconNameView.swift
@@ -87,11 +87,11 @@ extension EditCategoryIconNameView: View {
 
       MainButton(
         "완료",
-        isDisabled: store.categoryName.isEmpty
+        isDisabled: store.categoryName.isEmpty,
+        hasGradient: true
       ) {
         store.send(.compeleteButtonTapped)
       }
-      .padding(.horizontal, 20)
     }
     .background(DesignSystemAsset.background.swiftUIColor)
     .onTapGesture {

--- a/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/LinkDetailSegment.swift
+++ b/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/LinkDetailSegment.swift
@@ -14,7 +14,7 @@ struct LinkDetailSegment: View {
   @Binding var selectedTab: Tab
   
   enum Tab: String, CaseIterable, Identifiable {
-    case summary = "요약"
+    case summary = "하이라이트"
     case memo = "추가 메모"
     var id: String { rawValue }
   }
@@ -28,10 +28,10 @@ struct LinkDetailSegment: View {
 
 extension LinkDetailSegment {
   var body: some View {
-    VStack(spacing: 0) {
+    VStack(spacing: .zero) {
       contents
-      
-      Divider()
+        .padding(.bottom, -underlineHeight)
+      Rectangle()
         .frame(height: 1)
         .foregroundStyle(.divider1)
     }

--- a/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/SummaryTypeItem.swift
+++ b/Nbs/Projects/Feature/Sources/UIComponent/LinkDetail/SummaryTypeItem.swift
@@ -8,34 +8,26 @@
 import SwiftUI
 import DesignSystem
 
-/// 요약 아이템 (What / Why / Detail)
+/// 하이라이트 아이템 (Pink / Yellow / Blue)
 struct SummaryTypeItem: View {
   enum SummaryType: String {
-    case what = "What"
-    case why = "Why"
-    case detail = "Detail"
+    case pink = "Pink"
+    case yellow = "Yellow"
+    case blue = "Blue"
     
     var textColor: Color {
       switch self {
-      case .what: return .textWhat
-      case .why: return .textWhy
-      case .detail: return .textDetail
+      case .pink: return .textWhat
+      case .yellow: return .textWhy
+      case .blue: return .textDetail
       }
     }
     
     var backgroundColor: Color {
       switch self {
-      case .what: return .bgWhat
-      case .why: return .bgWhy
-      case .detail: return .bgDetail
-      }
-    }
-    
-    var shortLabel: String {
-      switch self {
-      case .what: return "W"
-      case .why: return "W"
-      case .detail: return "D"
+      case .pink: return .bgWhat
+      case .yellow: return .bgWhy
+      case .blue: return .bgDetail
       }
     }
   }
@@ -46,12 +38,9 @@ struct SummaryTypeItem: View {
 extension SummaryTypeItem {
   var body: some View {
     HStack(spacing: 8) {
-      Text(type.shortLabel)
-        .font(.B2_M)
-        .foregroundStyle(type.textColor)
+      RoundedRectangle(cornerRadius: 4)
+        .fill(type.backgroundColor)
         .frame(width: 24, height: 24)
-        .background(type.backgroundColor)
-        .cornerRadius(4)
       
       Text(type.rawValue)
         .font(.B1_M)
@@ -62,8 +51,8 @@ extension SummaryTypeItem {
 
 #Preview {
   VStack(spacing: 16) {
-    SummaryTypeItem(type: .what)
-    SummaryTypeItem(type: .why)
-    SummaryTypeItem(type: .detail)
+    SummaryTypeItem(type: .pink)
+    SummaryTypeItem(type: .yellow)
+    SummaryTypeItem(type: .blue)
   }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #94 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 기존 하이라이트 방식 wwd에서 색상으로 변경
- Segment와 Divider 사이 간격, 터치영역 수정
- 상단 navigationbar 여백 수정
- 링크 원문 보기 버튼 터치 영역 축소
- MainButton 그라데이션 추가
- bgButtonGrd 색상 변경

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/a7e6d1a1-edfd-4c8f-aa7e-1d722bc55741


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 일단 테플전 여기까지?느낌입니다.